### PR TITLE
fix: add social media icons to all footers and import FontAwesome (#47)

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cart - ChaatBazar</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -26,6 +27,12 @@
 </section>
 
 <footer>
+  <div class="social-icons">
+    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
+    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  </div>
   <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -158,6 +159,12 @@
 
 <!-- Footer -->
 <footer>
+  <div class="social-icons">
+    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
+    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  </div>
   <p>© 2026 ChaatBazar. All rights reserved.</p>
 </footer>
 

--- a/menu.html
+++ b/menu.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Menu - ChaatBazar</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -32,6 +33,12 @@
 </section>
 
 <footer>
+  <div class="social-icons">
+    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
+    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  </div>
   <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
 </footer>
 


### PR DESCRIPTION
## Description
This PR resolves issue #47 by importing the FontAwesome CDN and adding the \.social-icons\ container containing links to Facebook, Instagram, Twitter/X, and GitHub inside the footer across all HTML views (\index.html\, \cart.html\, and \menu.html\).

This removes unused/dead CSS styling for \.social-icons\ in \style.css\ and balances the design of the footer layout.

## Related Issue
Closes #47

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Markup / style enhancement (non-breaking change which adds style/layout functionality)

## How Has This Been Tested?
- [x] Verified footer layouts render correctly across all HTML views.
- [x] Verified FontAwesome icons scale and align perfectly.
- [x] Verified hover effects transition to \#ffccbc\ on social icons.

## GSSoC 2026 Contribution
Submitted as part of GirlScript Summer of Code 2026.