### PR TITLE
✨ [Feature Add] Add Share dish via Web Share API with WhatsApp fallback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1283,15 +1283,16 @@ mark.highlight {
   background: transparent;
   border: 1.5px solid #ff6b00;
   color: #ff6b00;
-  border-radius: 50px;
-  padding: 0.4rem 1rem;
-  font-size: 0.8rem;
-  font-weight: 600;
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  font-size: 0.85rem;
   cursor: pointer;
   transition: all 0.3s ease;
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  justify-content: center;
 }
 
 .share-btn:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -1273,6 +1273,38 @@ mark.highlight {
   transform: translateY(-1px);
 }
 
+.card-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.share-btn {
+  background: transparent;
+  border: 1.5px solid #ff6b00;
+  color: #ff6b00;
+  border-radius: 50px;
+  padding: 0.4rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.share-btn:hover {
+  background: #ff6b00;
+  color: #fff;
+  box-shadow: 0 4px 10px rgba(255, 107, 0, 0.35);
+  transform: translateY(-1px);
+}
+
+.share-btn:focus-visible {
+  outline: 2px solid #ff6b00;
+  outline-offset: 2px;
+}
 /* ===== Orders Dashboard Layout ===== */
 .orders-page {
   padding-top: 4rem;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>ChaatBazar 🍴 | Authentic Indian Street Food Delivered Hot</title>
   
   <!-- Google Fonts -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/js/main.js
+++ b/js/main.js
@@ -94,7 +94,7 @@ function createCard(item, highlightQuery = "") {
       <span class="price">${formatPrice(item.price)}</span>
       <div class="card-footer-actions">
         <button class="share-btn" aria-label="Share ${item.name}" title="Share via WhatsApp or other apps">
-          <i class="fas fa-share-alt"></i> Share
+          <i class="fas fa-share-alt"></i>
         </button>
         <button class="add-btn" aria-label="Add ${item.name} to cart">Add</button>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -92,12 +92,39 @@ function createCard(item, highlightQuery = "") {
     </div>
     <div class="card-footer">
       <span class="price">${formatPrice(item.price)}</span>
-      <button class="add-btn" aria-label="Add ${item.name} to cart">Add</button>
+      <div class="card-footer-actions">
+        <button class="share-btn" aria-label="Share ${item.name}" title="Share via WhatsApp or other apps">
+          <i class="fas fa-share-alt"></i> Share
+        </button>
+        <button class="add-btn" aria-label="Add ${item.name} to cart">Add</button>
+      </div>
     </div>
+
   `;
 
   const addBtn = card.querySelector(".add-btn");
   addBtn.addEventListener("click", () => addToCart(item.id));
+
+  const shareBtn = card.querySelector(".share-btn");
+  shareBtn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    const shareData = {
+      title: "ChaatBazaar 🍴",
+      text: `Check out this amazing dish — ${item.name} (${formatPrice(item.price)}) on ChaatBazaar! Authentic Indian street food delivered to your door 🌶️`,
+      url: window.location.href
+    };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+      } catch (err) {
+        // User cancelled — do nothing
+      }
+    } else {
+      const waText = encodeURIComponent(shareData.text + " " + shareData.url);
+      window.open(`https://wa.me/?text=${waText}`, "_blank");
+    }
+  });
 
   return card;
 }

--- a/menu.html
+++ b/menu.html
@@ -6,6 +6,7 @@
   <title>Menu - ChaatBazar</title>
   
   <!-- Google Fonts -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/style.css">
 </head>


### PR DESCRIPTION
Closes #49

## Changes Made
- `js/main.js` — Added share button HTML inside `card-footer` and share event listener using Web Share API with WhatsApp deep-link fallback
- `css/style.css` — Added `.share-btn` and `.card-footer-actions` styles consistent with orange theme

## Platform Behavior
- Android/iOS → Native share sheet
- Desktop Chrome/Edge → Native share dialog
- Firefox/Older browsers → WhatsApp deep-link fallback

## Screenshots
<img width="943" height="740" alt="Screenshot 2026-05-19 232024" src="https://github.com/user-attachments/assets/e5d64def-f2f4-4612-a883-75623dc74f5c" />
<img width="778" height="489" alt="Screenshot 2026-05-19 232319" src="https://github.com/user-attachments/assets/47c1d988-de5f-486d-b6ab-1fa8478d144f" />
<img width="760" height="536" alt="Screenshot 2026-05-19 232339" src="https://github.com/user-attachments/assets/9b32207f-e82a-43f2-a3d7-9e3b98e24c80" />
