### PR TITLE
Fix cart button functionality

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -473,7 +473,7 @@ window.reorderOrder = function(orderId) {
   const sidebar = document.getElementById("cart-sidebar");
   if (sidebar) {
     sidebar.setAttribute("aria-hidden", "false");
-    sidebar.style.transform = "translateX(0)";
+    sidebar.classList.add("open");
   }
 };
 
@@ -496,7 +496,7 @@ function addToCart(id) {
   // Slide open the cart sidebar automatically for a premium UX when adding items on index.html
   if (cartSidebar) {
     cartSidebar.setAttribute("aria-hidden", "false");
-    cartSidebar.style.transform = "translateX(0)";
+    cartSidebar.classList.add("open");
   }
 }
 
@@ -539,18 +539,18 @@ function setupCartToggle() {
   cartOpenBtn.addEventListener("click", (e) => {
     e.preventDefault();
     cartSidebar.setAttribute("aria-hidden", "false");
-    cartSidebar.style.transform = "translateX(0)";
+    cartSidebar.classList.add("open");
   });
 
   cartCloseBtn.addEventListener("click", () => {
     cartSidebar.setAttribute("aria-hidden", "true");
-    cartSidebar.style.transform = "translateX(100%)";
+    cartSidebar.classList.remove("open");
   });
 
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && cartSidebar.getAttribute("aria-hidden") === "false") {
       cartSidebar.setAttribute("aria-hidden", "true");
-      cartSidebar.style.transform = "translateX(100%)";
+      cartSidebar.classList.remove("open");
     }
   });
 }


### PR DESCRIPTION
Title
Fix cart button functionality

Description
This PR fixes the cart sidebar behavior in js/main.js by switching the open/close logic to use the existing open CSS class instead of setting inline transform values directly. This keeps the cart state consistent across add-to-cart, reorder, open, close, and Escape-key interactions.

What changed

Open the cart sidebar with cartSidebar.classList.add("open")
Close the cart sidebar with cartSidebar.classList.remove("open")
Apply the same class-based behavior to reorder flow and cart toggle handlers
Preserve aria-hidden updates alongside the visual state