### PR TITLE
fix: navbar dropdown filters, cart overlay close, inline qty controls, menu layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1539,3 +1539,39 @@ mark.highlight {
   box-shadow: 0 6px 20px rgba(191, 54, 12, 0.4);
   transform: translateY(-1px);
 }
+/* ===== Cart Overlay ===== */
+#cart-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1400;
+  cursor: pointer;
+}
+
+#cart-overlay.active {
+  display: block;
+}
+/* ===== Menu Page Layout ===== */
+.menu-page {
+  padding: 3rem 1rem 5rem;
+  background: #fff3e0;
+  min-height: 100vh;
+  max-width: 100%;  
+}
+
+.menu-page h1 {
+  text-align: center;
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: #bf360c;
+  margin-bottom: 2.5rem;
+}
+
+.menu-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  margin-top: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
   </div>
   <p>© 2026 ChaatBazar. All rights reserved.</p>
 </footer>
-
+<div id="cart-overlay" aria-hidden="true"></div>
 <script src="js/main.js"></script> 
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -92,13 +92,42 @@ function createCard(item, highlightQuery = "") {
     </div>
     <div class="card-footer">
       <span class="price">${formatPrice(item.price)}</span>
-      <button class="add-btn" aria-label="Add ${item.name} to cart">Add</button>
+      <div class="card-qty-control"></div>
     </div>
   `;
 
-  const addBtn = card.querySelector(".add-btn");
-  addBtn.addEventListener("click", () => addToCart(item.id));
+  const qtyControl = card.querySelector(".card-qty-control");
 
+  function renderCardFooter() {
+    const cartItem = cart.find(ci => ci.item.id === item.id);
+    const qty = cartItem ? cartItem.quantity : 0;
+
+    if (qty === 0) {
+      qtyControl.innerHTML = `<button class="add-btn" aria-label="Add ${item.name} to cart">Add</button>`;
+      qtyControl.querySelector(".add-btn").addEventListener("click", () => {
+        addToCart(item.id);
+        renderCardFooter();
+      });
+    } else {
+      qtyControl.innerHTML = `
+        <div class="qty-controls">
+          <button class="qty-decrease" aria-label="Decrease ${item.name}">−</button>
+          <span>${qty}</span>
+          <button class="qty-increase" aria-label="Increase ${item.name}">+</button>
+        </div>
+      `;
+      qtyControl.querySelector(".qty-decrease").addEventListener("click", () => {
+        removeFromCart(item.id);
+        renderCardFooter();
+      });
+      qtyControl.querySelector(".qty-increase").addEventListener("click", () => {
+        addToCart(item.id);
+        renderCardFooter();
+      });
+    }
+  }
+
+  renderCardFooter();
   return card;
 }
 
@@ -474,6 +503,8 @@ window.reorderOrder = function(orderId) {
   if (sidebar) {
     sidebar.setAttribute("aria-hidden", "false");
     sidebar.classList.add("open");
+    const overlay = document.getElementById("cart-overlay");
+    if (overlay) overlay.classList.add("active");
   }
 };
 
@@ -494,10 +525,12 @@ function addToCart(id) {
   saveCart();
 
   // Slide open the cart sidebar automatically for a premium UX when adding items on index.html
-  if (cartSidebar) {
-    cartSidebar.setAttribute("aria-hidden", "false");
-    cartSidebar.classList.add("open");
-  }
+  // if (cartSidebar) {
+  //   cartSidebar.setAttribute("aria-hidden", "false");
+  //   cartSidebar.classList.add("open");
+  //   const overlay = document.getElementById("cart-overlay");
+  //   if (overlay) overlay.classList.add("active");
+  // }
 }
 
 function removeFromCart(id) {
@@ -530,27 +563,65 @@ function setupFilterButtons() {
     });
   });
 }
+function setupNavDropdownFilters() {
+  const menuFilterLinks = document.querySelectorAll(".menu-filter");
+  menuFilterLinks.forEach(link => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      const filter = link.dataset.filter;
+
+      // scroll to #menu section
+      const menuSection = document.getElementById("menu");
+      if (menuSection) menuSection.scrollIntoView({ behavior: "smooth" });
+
+      // apply the filter
+      renderMenu(filter);
+
+      // sync the active state on the .filter-btn buttons
+      const filterButtons = document.querySelectorAll(".filter-btn");
+      filterButtons.forEach(btn => {
+        if (btn.dataset.filter === filter) {
+          btn.classList.add("active");
+          btn.setAttribute("aria-pressed", "true");
+        } else {
+          btn.classList.remove("active");
+          btn.setAttribute("aria-pressed", "false");
+        }
+      });
+    });
+  });
+}
+
 
 function setupCartToggle() {
   const cartOpenBtn = document.getElementById("cart-open-btn");
   const cartCloseBtn = document.getElementById("cart-close");
+  const overlay = document.getElementById("cart-overlay");
   if (!cartOpenBtn || !cartCloseBtn || !cartSidebar) return;
 
   cartOpenBtn.addEventListener("click", (e) => {
     e.preventDefault();
     cartSidebar.setAttribute("aria-hidden", "false");
     cartSidebar.classList.add("open");
+     if (overlay) overlay.classList.add("active");
   });
 
   cartCloseBtn.addEventListener("click", () => {
     cartSidebar.setAttribute("aria-hidden", "true");
     cartSidebar.classList.remove("open");
+    if (overlay) overlay.classList.remove("active");
+  });
+  if (overlay) overlay.addEventListener("click", () => {  // ADD entire block
+    cartSidebar.setAttribute("aria-hidden", "true");
+    cartSidebar.classList.remove("open");
+    overlay.classList.remove("active");
   });
 
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && cartSidebar.getAttribute("aria-hidden") === "false") {
       cartSidebar.setAttribute("aria-hidden", "true");
       cartSidebar.classList.remove("open");
+      if (overlay) overlay.classList.remove("active"); 
     }
   });
 }
@@ -867,6 +938,7 @@ async function init() {
   // Bind interactive UI listeners immediately for instant input responsiveness (high INP)
   setupCartToggle();
   setupFilterButtons();
+  setupNavDropdownFilters();
   setupOrderNowScroll();
   setupSearchSuggestions();
   setupSearch();

--- a/menu.html
+++ b/menu.html
@@ -29,7 +29,8 @@
       </div>
       <a href="index.html#about" class="nav-link">About</a>
       <a href="orders.html" class="nav-link">Orders</a>
-      <a href="cart.html" class="nav-link">Cart</a>
+      <a href="#cart-sidebar" class="nav-link" id="cart-open-btn" aria-label="Open Cart">Cart (<span id="cart-count">0</span>)</a>
+
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
         <button aria-label="Search" id="search-btn"></button>
@@ -120,6 +121,19 @@
   </div>
   <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
 </footer>
+<aside id="cart-sidebar" role="region" aria-label="Shopping Cart" aria-hidden="true">
+  <div id="cart-header">
+    Your Cart
+    <button id="cart-close" aria-label="Close Cart">&times;</button>
+  </div>
+  <div id="cart-items" tabindex="0" aria-live="polite" aria-relevant="additions removals">
+  </div>
+  <div id="cart-footer">
+    <span id="cart-total">Total: ₹0</span>
+    <button id="checkout-btn" disabled>Checkout</button>
+  </div>
+</aside>
+<div id="cart-overlay" aria-hidden="true"></div>
 
 <script src="js/main.js"></script>
 </body>

--- a/orders.html
+++ b/orders.html
@@ -28,7 +28,7 @@
       </div>
       <a href="index.html#about" class="nav-link">About</a>
       <a href="orders.html" class="nav-link active">Orders</a>
-      <a href="cart.html" class="nav-link">Cart</a>
+      <a href="#cart-sidebar" class="nav-link" id="cart-open-btn" aria-label="Open Cart">Cart (<span id="cart-count">0</span>)</a>
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
         <button aria-label="Search" id="search-btn"></button>
@@ -49,6 +49,19 @@
 <footer>
   <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
 </footer>
+<aside id="cart-sidebar" role="region" aria-label="Shopping Cart" aria-hidden="true">
+  <div id="cart-header">
+    Your Cart
+    <button id="cart-close" aria-label="Close Cart">&times;</button>
+  </div>
+  <div id="cart-items" tabindex="0" aria-live="polite" aria-relevant="additions removals">
+  </div>
+  <div id="cart-footer">
+    <span id="cart-total">Total: ₹0</span>
+    <button id="checkout-btn" disabled>Checkout</button>
+  </div>
+</aside>
+<div id="cart-overlay" aria-hidden="true"></div>
 
 <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
Changes made:
- Added setupNavDropdownFilters() in main.js to wire up navbar dropdown category links
- Added #cart-overlay click-outside logic to close cart sidebar  
- Updated createCard() in main.js to show inline − qty + controls on menu cards
- Added .menu-container styles in style.css for proper card spacing on menu.html
