### PR TITLE
docs: add 📁 Project Structure section to README, resolves issue #121

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ChaatBazaar/
 ├── LICENSE                # MIT License file
 ├── menu.html              # Browse-able items list page
 ├── orders.html            # User order history or current order details page
-└── README.md              # Project documentation file
+└── README.md              # Project documentation
 
 ## 💻 Tech Stack <a name="-tech-stack"></a>
 Built with modern, lightweight web technologies:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,40 @@ Demo Link : <a href="https://patelharsh2006.github.io/ChaatBazaar/">Link</a>
 
 <img src="https://capsule-render.vercel.app/api?type=rect&height=4&color=FF7B54" width="100%">
 
+## 📁 Project Structure
+
+Below is the directory layout of the ChaatBazaar project to help you navigate the codebase:
+
+```text
+ChaatBazaar/
+├── .github/               # GitHub configuration
+│   └── workflows/         # CI/CD automation pipelines
+│       └── ci.yml         # Continuous Integration workflow configuration
+├── css/                   # Stylesheets for the application
+│   ├── 404.css            # Styling specific to the error page
+│   └── style.css          # Main global styles and theme configurations
+├── data/                  # Local data storage files
+│   └── menu.json          # Structured menu item data (dishes, prices, states)
+├── img/                   # Asset directory for static images and graphics
+│   ├── 1.avif             # Food item image asset
+│   ├── 2.avif             # Food item image asset
+│   ├── 7.avif             # Food item image asset
+│   ├── 8.avif             # Food item image asset
+│   ├── 9.avif             # Food item image asset
+│   └── chaat.png          # Main application logo/banner asset
+├── js/                    # Application client-side scripting
+│   └── main.js            # Core JavaScript logic (cart operations, filtering)
+├── 404.html               # Custom 404 Error Page
+├── about.html             # Information about ChaatBazaar
+├── cart.html              # User shopping cart and order confirmation page
+├── CONTRIBUTING.md        # Detailed rules and setup guidelines for contributors
+├── favicon.png            # Browser tab icon asset
+├── index.html             # Application entry point (Landing / Home Page)
+├── LICENSE                # MIT License file
+├── menu.html              # Browse-able items list page
+├── orders.html            # User order history or current order details page
+└── README.md              # Project documentation file
+
 ## 💻 Tech Stack <a name="-tech-stack"></a>
 Built with modern, lightweight web technologies:
 * <img src="https://img.shields.io/badge/HTML5-E34F26?style=flat-square&logo=html5&logoColor=white" alt="HTML5" />


### PR DESCRIPTION
Description
This pull request addresses the open documentation issue by adding a dedicated 📁 Project Structure section to the main README.md.

The new section introduces a clear, visual overview of the directory layout, explaining the purpose of key folders (such as GitHub workflows, stylesheets, and local JSON data) as well as the main HTML pages. This helps new and first-time contributors quickly understand how the project is organized and where to look when they get started.

Related Issue
Closes #<Put_The_Issue_Number_Here>

Type of Change
Documentation update (non-breaking change that improves project clarity)

Checklist
Followed the existing formatting and style guidelines

Synced my fork with the upstream main branch before committing

Confirmed that all code blocks and markdown elements render correctly