### PR TITLE
Fix menu card spacing and centering issue in menu.html

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,6 +224,15 @@
       margin-bottom: 2.5rem;
       user-select: none;
     }
+    
+    .menu-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  align-items: flex-start;
+}
+
     .cards {
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
## Description

Fixed the spacing and alignment issue of menu cards in `menu.html`.

### Changes Made

* Added proper flexbox styling to `.menu-container`
* Added spacing between cards using `gap`
* Centered the menu card layout using `justify-content: center`
* Improved alignment consistency with `align-items: flex-start`

### Issue Fixed

Menu cards were not properly centered and lacked spacing, causing inconsistent UI compared to `index.html`.

Closes #158
