### PR TITLE
fix: handle localStorage quota exceeded errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.sublime-project
+.sublime-workspace
+*.iml
+
+# Build outputs
+dist/
+build/
+*.bundle.js
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+
+# Logs
+logs/
+*.log
+
+# Temporary files
+*.tmp
+tmp/
+temp/
+
+# Package managers
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Local development
+.vscode-settings.json
+
+# Personal audit reports & drafts (keep locally)
+CONTRIBUTION_IDEAS.md
+DEVELOPMENT.md
+SECURITY_AUDIT_REPORT.md
+CRITICAL_BUGS_TO_FIX.md
+personal-notes.md
+ideas/
+audit/
+reports/

--- a/js/cart-manager.js
+++ b/js/cart-manager.js
@@ -29,8 +29,21 @@ class CartManager {
       // Dispatch custom event for cross-tab/cross-component sync
       window.dispatchEvent(new CustomEvent(CART_SYNC_EVENT, { detail: this.items }));
     } catch (error) {
-      console.error('Error saving cart to storage:', error);
+      if (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+        console.error('Storage quota exceeded:', error);
+        this.handleStorageQuotaExceeded();
+      } else {
+        console.error('Error saving cart to storage:', error);
+      }
     }
+  }
+
+  // Handle storage quota exceeded
+  handleStorageQuotaExceeded() {
+    const message = 'Storage limit exceeded. Your cart may not be saved. Please clear browser cache and try again.';
+    console.warn(message);
+    // Dispatch event for UI to show notification
+    window.dispatchEvent(new CustomEvent('storageQuotaExceeded', { detail: message }));
   }
 
   // Setup storage event listener for cross-tab sync

--- a/js/recently-viewed.js
+++ b/js/recently-viewed.js
@@ -1,0 +1,50 @@
+const RecentlyViewed = {
+  storageKey: 'chaatRecentlyViewed',
+  maxItems: 10,
+
+  getItems() {
+    try {
+      const items = localStorage.getItem(this.storageKey);
+      return items ? JSON.parse(items) : [];
+    } catch (error) {
+      console.error('RecentlyViewed data corrupted, clearing:', error);
+      try {
+        localStorage.removeItem(this.storageKey);
+      } catch (e) {
+        console.error('Error clearing corrupted recently viewed data:', e);
+      }
+      return [];
+    }
+  },
+
+  addItem(item) {
+    try {
+      let items = this.getItems();
+      items = items.filter(i => i.id !== item.id);
+      items.unshift({ ...item, viewedAt: Date.now() });
+      items = items.slice(0, this.maxItems);
+      localStorage.setItem(this.storageKey, JSON.stringify(items));
+    } catch (error) {
+      if (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+        console.warn('Storage quota exceeded for recently viewed items');
+        window.dispatchEvent(new CustomEvent('storageQuotaExceeded', {
+          detail: 'Cannot save recently viewed items - storage limit exceeded'
+        }));
+      } else {
+        console.error('Error adding to recently viewed:', error);
+      }
+    }
+  },
+
+  clear() {
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch (error) {
+      console.error('Error clearing recently viewed:', error);
+    }
+  },
+
+  hasItems() {
+    return this.getItems().length > 0;
+  }
+};


### PR DESCRIPTION
- Add proper error handling in CartManager.saveToStorage() for QuotaExceededError
- Add handleStorageQuotaExceeded() method to dispatch notification event
- Create RecentlyViewed module with quota error handling
- Add .gitignore with proper exclusions for local audit files
- Dispatch 'storageQuotaExceeded' event for UI notification
- Clear corrupted recently viewed data on JSON parse errors
- Gracefully degrade when storage is full instead of silent failure

Fixes localStorage quota exceeded not handled
Fixes Error boundary missing in RecentlyViewed
closes #253 