### PR TITLE
[Fix] Load menu from menu.json instead of hardcoded array (refs #90)

### DIFF
--- a/data/menu.json
+++ b/data/menu.json
@@ -1,7 +1,52 @@
 [
-  {"id":1,"name":"Samosa","category":"Snacks","price":15,"spice":"Medium","image":"../img/samosa.jpg"},
-  {"id":2,"name":"Kachori","category":"Snacks","price":20,"spice":"Medium","image":"../img/9.avif"},
-  {"id":3,"name":"Pani Puri","category":"Chaat","price":30,"spice":"High","image":"../img/panipuri.jpg"},
-  {"id":4,"name":"Sev Puri","category":"Chaat","price":35,"spice":"High","image":"../img/sevpuri.jpg"},
-  {"id":5,"name":"Chai","category":"Beverages","price":10,"spice":"Low","image":"../img/chai.jpg"}
+  {
+    "id": 1,
+    "name": "Samosa",
+    "category": "Snacks",
+    "price": 30,
+    "description": "Crispy golden triangle stuffed with spiced potatoes.",
+    "image": "img/8.avif",
+    "spice": "medium",
+    "isSpecial": true
+  },
+  {
+    "id": 2,
+    "name": "Pani Puri",
+    "category": "Chaat",
+    "price": 50,
+    "description": "Hollow crispy puris filled with spicy, tangy water and chickpeas.",
+    "image": "img/2.avif",
+    "spice": "high",
+    "isSpecial": true
+  },
+  {
+    "id": 3,
+    "name": "Masala Chai",
+    "category": "Beverages",
+    "price": 20,
+    "description": "Aromatic tea brewed with spices and milk.",
+    "image": "img/7.avif",
+    "spice": "low",
+    "isSpecial": true
+  },
+  {
+    "id": 4,
+    "name": "Kachori",
+    "category": "Snacks",
+    "price": 35,
+    "description": "Deep-fried pastry filled with spicy lentils.",
+    "image": "img/9.avif",
+    "spice": "medium",
+    "isSpecial": false
+  },
+  {
+    "id": 5,
+    "name": "Bhel Puri",
+    "category": "Chaat",
+    "price": 45,
+    "description": "Crunchy puffed rice mixed with tangy tamarind chutney.",
+    "image": "img/1.avif",
+    "spice": "low",
+    "isSpecial": false
+  }
 ]

--- a/js/main.js
+++ b/js/main.js
@@ -1,45 +1,19 @@
-const menuItems = [
-  {
-    id: 1,
-    name: "Samosa",
-    category: "Snacks",
-    price: 30,
-    description: "Crispy golden triangle stuffed with spiced potatoes.",
-    image: "img/8.avif"
-  },
-  {
-    id: 2,
-    name: "Pani Puri",
-    category: "Chaat",
-    price: 50,
-    description: "Hollow crispy puris filled with spicy, tangy water and chickpeas.",
-    image: "img/2.avif"
-  },
-  {
-    id: 3,
-    name: "Masala Chai",
-    category: "Beverages",
-    price: 20,
-    description: "Aromatic tea brewed with spices and milk.",
-    image: "img/7.avif"
-  },
-  {
-    id: 4,
-    name: "Kachori",
-    category: "Snacks",
-    price: 35,
-    description: "Deep-fried pastry filled with spicy lentils.",
-    image: "img/9.avif"
-  },
-  {
-    id: 5,
-    name: "Bhel Puri",
-    category: "Chaat",
-    price: 45,
-    description: "Crunchy puffed rice mixed with tangy tamarind chutney.",
-    image: "img/1.avif"
-  },
-];
+let menuItems = []; 
+
+async function loadMenu() {
+  try {
+    const response = await fetch('data/menu.json');
+    if (!response.ok) throw new Error('Failed to load menu');
+    menuItems = await response.json();
+    
+    renderMenu('All');
+    renderSpecials();
+  } catch (err) {
+    console.error('Menu load error:', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadMenu);
 
 // ===== Globals =====
 const specialsContainer = document.getElementById("specials-cards");
@@ -88,7 +62,7 @@ function createCard(item) {
 }
 
 function renderSpecials() {
-  const specials = menuItems.slice(0, 3);
+  const specials = menuItems.filter(item => item.isSpecial);
 
   // 1. Show skeletons immediately
   showSkeletonCards(specialsContainer, specials.length);


### PR DESCRIPTION
Refs #90 (I narrowed the scope after parts of the issue went out of date — see issue comments).

## What this PR does

**Before:** `js/main.js` had a hardcoded list of menu items. `data/menu.json` existed but was never used.

**After:** The menu items live in `data/menu.json`, and the website loads them from there on page open.

## Files changed

**`data/menu.json`** — Rewrote it to match what's currently on the live site (same prices, names, descriptions, image paths). Added two new fields:
- `spice` — for the existing spice-level filter
- `isSpecial` — set to `true` for the 3 items shown in "Today's Specials"

**`js/main.js`** — Two changes:
- Removed the hardcoded `menuItems` array. The page now fetches `data/menu.json` when it loads.
- Changed `renderSpecials()` from `menuItems.slice(0, 3)` to `menuItems.filter(item => item.isSpecial)`. So which items are "special" is now decided by the JSON file, not by their position in the array.

## What I did not change

The issue also mentioned a "broken Specials filter showing 'No items found'." That part doesn't apply anymore — on the current site, the Specials link in the navbar just scrolls to the Today's Specials section. There's no filter to fix. Full reasoning in the issue comments.

## How to test

1. Open `index.html` using a local server (Live Server, `python -m http.server`, etc.). It won't work by double-clicking the file because `fetch()` needs HTTP.
2. Open DevTools → Network tab → hard reload (Ctrl+Shift+R).
3. You should see `menu.json` load with status `200`.
4. "Today's Specials" shows 3 cards.
5. "Explore Our Menu" shows all 5 cards. Filter buttons still work.

Also tested on `menu.html` (same `js/main.js`) — no regressions.

## Screenshots
<img width="1919" height="863" alt="image" src="https://github.com/user-attachments/assets/de2bd0a1-2d87-4c2f-9557-e58836b284f2" />
[Network tab showing menu.json: 200]
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/9a138bd8-0a7e-4d5f-b078-6de2fd79dc18" />
[Today's Specials with 3 cards]
<img width="1915" height="867" alt="image" src="https://github.com/user-attachments/assets/07b0d4fa-40bd-453f-8c94-a92f5660a62f" />
[Explore Our Menu with all 5 cards]

## Notes

- The README line "JSON for menu data storage" is now actually true — no doc updates needed.

cc @PatelHarsh2006