### PR TITLE
fix(menu): restore Add button hover state (#80)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -97,7 +97,7 @@ function createCard(item, highlightQuery = "") {
 
   //Disables button and change color if out of stock
   const buttonDisabled = !isAvailable ? 'disabled' : '';
-  const buttonColor = isAvailable ? '#28a745' : '#cccccc';
+
 
   card.innerHTML = `
     <img src="${item.image}" alt="${item.name}" loading="lazy" />
@@ -115,8 +115,7 @@ function createCard(item, highlightQuery = "") {
       <span class="price">${formatPrice(item.price)}</span>
       <button class="add-btn" 
         aria-label="Add ${item.name} to cart" 
-        ${buttonDisabled}
-        style="background-color: ${buttonColor};">
+        ${buttonDisabled}>
         Add
       </button>
     </div>


### PR DESCRIPTION
**Title:** `fix(menu): restore Add button hover state (#80)`

---

## Summary
Restores the missing hover state on the **Add** button across all product cards.

Fixes #80

## Problem
On every product card in *Today's Specials*, *Recently Viewed*, and *Explore Our Menu*, hovering the Add button produced no visual feedback. The CSS hover rule was defined but never had any effect.

## Root cause
`createCard()` in `js/main.js` was rendering the button with an inline `style="background-color: …"` attribute. Inline `style` declarations win over external CSS for the same property, so the inline `background-color` was overriding the `:hover` rule's `background` change on every hover event.

The class-name mismatch called out in the issue (`btn-add` in CSS vs `add-btn` in JS) is real but is a separate orange-theme leftover — the maintainer has confirmed the green color is intentional, so this PR does **not** touch that path.

## Fix
Remove the inline `style` attribute (and the now-unused `buttonColor` variable that fed it) from the `createCard()` template. The existing CSS then takes over on its own:

- `.card-footer .add-btn` paints the available button green (`#2e7d32`)
- `.card-footer .add-btn:hover` darkens it to `#1b5e20` with the shadow and 1px lift
- `.add-btn:disabled { background-color: #cccccc !important; }` keeps out-of-stock items grey


## Theme preserved
Per the maintainer's note that the off-theme green is intentional, the button color is **unchanged**. This PR only restores the missing hover transition.
