### PR TITLE
Fix #342: resolve responsive team card collapse on smaller screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -605,17 +605,20 @@
       flex-wrap: wrap;
       margin-bottom: 3rem;
     }
-    .team-member {
-  flex: 1 1 380px;
-  max-width: 420px;
-  height: 320px;
-  perspective: 1000px;
-  background: transparent;
-  border-radius: 20px;
-  box-shadow: none;
-  padding: 0;
-  text-align: center;
-  user-select: none;
+   
+   .team-member {
+   width: 100%;
+   max-width: 420px;
+   min-width: 280px;
+   height: 320px;
+   flex: 1 1 320px;
+   perspective: 1000px;
+   background: transparent;
+   border-radius: 20px;
+   box-shadow: none;
+   padding: 0;
+   text-align: center;
+   user-select: none;
 }
 
 .team-member-inner {
@@ -1066,6 +1069,14 @@
       }
     }
 
+    /*=====Team member layout Fix===*/
+
+    @media (max-width: 768px) {
+    .team-member {
+    min-width: 100%;
+    max-width: 100%;
+  }
+  }
     /* ===== Mobile Navbar Fix ===== */
 @media (max-width: 480px) {
 


### PR DESCRIPTION
I am working under GSSoC'26 and this PR fixes #342 

---

## Description
This PR fixes the responsive layout issue where the team member cards collapsed into narrow vertical strips around 600 px (before and after screenshots are attached below.

---

## Changes Made
Added min-width to .team-member cards to prevent extra shrinking .
Improved the flex behavior for better responsiveness.
Made sure that the team member cards are vertically stacked and do not shrink, even for smaller screens.

---

## Screenshots
BEFORE----->

for > 600 px

<img width="999" height="802" alt="Screenshot 2026-05-28 213005" src="https://github.com/user-attachments/assets/932b9937-417e-4ef7-8c33-b5485203f9c1" />

<600px

<img width="1007" height="822" alt="Screenshot 2026-05-28 192229" src="https://github.com/user-attachments/assets/a3414673-fe64-4998-8400-7893482974e5" />




AFTER---->

for >600px

<img width="940" height="811" alt="Screenshot 2026-05-28 192216" src="https://github.com/user-attachments/assets/a6121d0a-5796-4da4-9934-06762e342b34" />


<600px

<img width="998" height="824" alt="Screenshot 2026-05-28 213017" src="https://github.com/user-attachments/assets/283ca66a-bd41-48d8-8467-9019ce843d2c" />

---

## Type of Change
- [x] Bug Fix
- [x] Responsive UI improvement
---

Thankyou. Happy to contribute :) 



