### PR TITLE
Redesign theme-toggle button with custom SVGs and animations

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -19,6 +19,17 @@
     <a href="cart.html">Cart</a>
     <a href="index.html#about">About</a>
     <a href="orders.html">Orders</a>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+      <span class="theme-toggle-track">
+        <span class="theme-toggle-icon sun-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        </span>
+        <span class="theme-toggle-icon moon-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </span>
+        <span class="theme-toggle-thumb"></span>
+      </span>
+    </button>
   </nav>
 </header>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1850,18 +1850,97 @@ mark.highlight {
 }
 /* ===== Dark Mode Theme ===== */
 .theme-toggle {
-  padding: 8px 12px;
-  border: none;
-  border-radius: 6px;
-  background: #e64a19;
-  color: white;
-  font-size: 16px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 68px;
+  height: 32px;
+  padding: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 99px;
+  background-color: #f2f4f7;
   cursor: pointer;
-  transition: 0.3s;
+  transition: background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.05);
 }
 
 .theme-toggle:hover {
-  background: #e66900;
+  border-color: rgba(255, 87, 34, 0.3);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid #ff5722 !important;
+  outline-offset: 2px;
+}
+
+.theme-toggle-track {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+  padding: 0 4px;
+}
+
+.theme-toggle-thumb {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #ffa726; /* vibrant orange/yellow for light mode */
+  box-shadow: 0 2px 6px rgba(255, 167, 38, 0.4);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1;
+}
+
+.theme-toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  z-index: 2;
+  pointer-events: none;
+  transition: color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.theme-toggle-icon svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2.5;
+}
+
+.theme-toggle-icon.sun-icon {
+  color: #ffffff; /* Active in light mode */
+}
+
+.theme-toggle-icon.moon-icon {
+  color: #8e9aa8; /* Inactive in light mode */
+}
+
+/* Dark mode specific overrides for theme toggle */
+body.dark .theme-toggle {
+  background-color: #15191e;
+  border-color: rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.3);
+}
+
+body.dark .theme-toggle-thumb {
+  transform: translateX(36px);
+  background-color: #2b3648; /* Slate blue for dark mode */
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+body.dark .theme-toggle-icon.sun-icon {
+  color: #5f6d7e; /* Inactive in dark mode */
+}
+
+body.dark .theme-toggle-icon.moon-icon {
+  color: #ffffff; /* Active in dark mode */
 }
 /* body */
 body.dark {

--- a/faq.html
+++ b/faq.html
@@ -223,6 +223,17 @@
         <button aria-label="Search" id="search-btn"></button>
         <div class="search-suggestions" id="search-suggestions" style="display:none;"></div>
       </div>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+        <span class="theme-toggle-track">
+          <span class="theme-toggle-icon sun-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          </span>
+          <span class="theme-toggle-icon moon-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </span>
+          <span class="theme-toggle-thumb"></span>
+        </span>
+      </button>
     </nav>
   </div>
 </header>

--- a/favorites.html
+++ b/favorites.html
@@ -38,6 +38,17 @@
           <button aria-label="Search" id="search-btn"></button>
           <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
         </div>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+          <span class="theme-toggle-track">
+            <span class="theme-toggle-icon sun-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+            </span>
+            <span class="theme-toggle-icon moon-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+            </span>
+            <span class="theme-toggle-thumb"></span>
+          </span>
+        </button>
       </nav>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,17 @@
         <button aria-label="Search" id="search-btn"></button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
-  <button id="theme-toggle" class="theme-toggle">🌙</button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+        <span class="theme-toggle-track">
+          <span class="theme-toggle-icon sun-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          </span>
+          <span class="theme-toggle-icon moon-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </span>
+          <span class="theme-toggle-thumb"></span>
+        </span>
+      </button>
     </nav>
   </div>
 </header>

--- a/js/main.js
+++ b/js/main.js
@@ -1257,9 +1257,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (savedTheme === "dark") {
     document.body.classList.add("dark");
-    if (toggleBtn) toggleBtn.textContent = "☀️";
-  } else {
-    if (toggleBtn) toggleBtn.textContent = "🌙";
   }
 });
 
@@ -1269,10 +1266,8 @@ if (toggleBtn) {
     document.body.classList.toggle("dark");
 
     if (document.body.classList.contains("dark")) {
-      toggleBtn.textContent = "☀️";
       localStorage.setItem("theme", "dark");
     } else {
-      toggleBtn.textContent = "🌙";
       localStorage.setItem("theme", "light");
     }
   });

--- a/menu.html
+++ b/menu.html
@@ -36,6 +36,17 @@
         <button aria-label="Search" id="search-btn"></button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+        <span class="theme-toggle-track">
+          <span class="theme-toggle-icon sun-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          </span>
+          <span class="theme-toggle-icon moon-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </span>
+          <span class="theme-toggle-thumb"></span>
+        </span>
+      </button>
     </nav>
   </div>
 </header>

--- a/orders.html
+++ b/orders.html
@@ -37,7 +37,17 @@
         <button aria-label="Search" id="search-btn"></button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
-      <button id="theme-toggle" class="theme-toggle">🌙</button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">
+        <span class="theme-toggle-track">
+          <span class="theme-toggle-icon sun-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          </span>
+          <span class="theme-toggle-icon moon-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+          </span>
+          <span class="theme-toggle-thumb"></span>
+        </span>
+      </button>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
This pull request upgrades the theme toggle button across the site to a more visually appealing, accessible, and consistent component. The new toggle uses SVG icons for sun and moon, a sliding thumb indicator, and improved styles for both light and dark modes. The update also removes the old emoji-based toggle and related JavaScript logic for changing the button's text.

**Theme toggle UI and accessibility improvements:**
<img width="1810" height="78" alt="image" src="https://github.com/user-attachments/assets/cf86ee41-5b02-4f35-a159-301520c85b7a" />

* Replaced the old emoji-based theme toggle button with a new component featuring SVG sun and moon icons, a sliding thumb, and improved accessibility (`aria-label="Toggle Theme"`) in `index.html`, `orders.html`, `menu.html`, `favorites.html`, `faq.html`, and `cart.html`.
* 
**Styling enhancements:**

* Overhauled the `.theme-toggle` styles in `css/style.css` to support the new toggle's layout, animations, SVG icon coloring, and dark mode overrides. This includes a sliding thumb effect and color changes for both icons depending on the theme.

**JavaScript logic cleanup:**

* Removed JavaScript code in `js/main.js` that updated the toggle button's emoji/text content, since the new design uses icons and a thumb instead. 

issuenum: #323 
/gssoc26