### PR TITLE
 Fix Exposed Accessibility Skip Link due to CSS Syntax Error

### DIFF
--- a/about.html
+++ b/about.html
@@ -124,13 +124,66 @@
 </main>
 
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <div id="toast-notification" class="toast-notification"></div>

--- a/cart.html
+++ b/cart.html
@@ -69,13 +69,66 @@
 </section>
 
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <div id="toast-notification" class="toast-notification"></div>

--- a/css/style.css
+++ b/css/style.css
@@ -1106,18 +1106,26 @@
       max-width: 1200px;
       margin: 0 auto;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 2.5rem;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 2rem;
       margin-bottom: 3rem;
     }
     
-    /* Brand Column (larger) */
-    .footer-column.brand-col {
-      grid-column: span 2;
+    @media (max-width: 1024px) {
+      .footer-container {
+        grid-template-columns: repeat(3, 1fr);
+      }
     }
-    @media (max-width: 992px) {
-      .footer-column.brand-col {
-        grid-column: span 1;
+    
+    @media (max-width: 768px) {
+      .footer-container {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+    
+    @media (max-width: 480px) {
+      .footer-container {
+        grid-template-columns: 1fr;
       }
     }
     

--- a/css/style.css
+++ b/css/style.css
@@ -1092,32 +1092,165 @@
       background: #fbe9e7;
     }
 
-    /* ===== Footer ===== */
+    /* ===== Modern Premium Footer ===== */
     footer {
-      background: #bf360c;
-      color: white;
-      text-align: center;
-      padding: 2rem 1rem;
-      user-select: none;
+      background: #fff3e0; /* Warm cream background */
+      color: #3e2723; /* Deep warm brown text */
+      padding: 4rem 2rem 2rem;
+      border-top: 1px solid rgba(255, 87, 34, 0.15);
+      user-select: text; /* Allow selecting text */
+      font-family: 'Poppins', sans-serif;
     }
-    footer p {
-      font-weight: 600;
+    
+    .footer-container {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 2.5rem;
+      margin-bottom: 3rem;
+    }
+    
+    /* Brand Column (larger) */
+    .footer-column.brand-col {
+      grid-column: span 2;
+    }
+    @media (max-width: 992px) {
+      .footer-column.brand-col {
+        grid-column: span 1;
+      }
+    }
+    
+    .footer-brand {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: #ff5722; /* Vibrant orange logo */
       margin-bottom: 1rem;
-      font-size: 0.9rem;
-    }
-    .social-icons {
       display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-family: 'Poppins', sans-serif;
+    }
+    
+    .footer-desc {
+      font-size: 0.95rem;
+      color: #5d4037;
+      line-height: 1.6;
+      max-width: 320px;
+    }
+    
+    .footer-column h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      color: #bf360c; /* Deep brand orange */
+      margin-bottom: 1.25rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    
+    .footer-links {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    
+    .footer-links li a {
+      color: #5d4037;
+      font-size: 0.95rem;
+      font-weight: 500;
+      transition: all 0.2s ease;
+      display: inline-block;
+    }
+    
+    .footer-links li a:hover {
+      color: #ff5722;
+      transform: translateX(3px);
+    }
+    
+    .footer-contact-info {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      color: #5d4037;
+      font-size: 0.95rem;
+    }
+    
+    .footer-contact-info li {
+      line-height: 1.5;
+    }
+    
+    .footer-contact-info strong {
+      color: #bf360c;
+    }
+    
+    .footer-social-wrapper {
+      margin-bottom: 1.5rem;
+    }
+    
+    .footer-social-icons {
+      display: flex;
+      gap: 1rem;
+      margin-top: 0.5rem;
+    }
+    
+    .footer-social-icons a {
+      display: flex;
+      align-items: center;
       justify-content: center;
-      gap: 1.5rem;
-      margin-bottom: 0.8rem;
+      width: 38px;
+      height: 38px;
+      border-radius: 50%;
+      background: #ff5722;
+      color: white !important;
+      font-size: 1.1rem;
+      transition: all 0.3s ease;
     }
-    .social-icons a {
-      color: white;
-      font-size: 1.5rem;
-      transition: color 0.3s ease;
+    
+    .footer-social-icons a:hover {
+      background: #bf360c;
+      transform: translateY(-3px);
+      box-shadow: 0 4px 10px rgba(255, 87, 34, 0.3);
     }
-    .social-icons a:hover {
-      color: #ffccbc;
+    
+    .footer-bottom {
+      border-top: 1px solid rgba(255, 87, 34, 0.1);
+      padding-top: 1.5rem;
+      text-align: center;
+      font-size: 0.9rem;
+      color: #8d6e63;
+      font-weight: 500;
+    }
+    
+    .footer-bottom p {
+      margin: 0;
+    }
+    
+    /* Dark Mode Overrides */
+    body.dark footer {
+      background: #1e1e1e;
+      border-top-color: rgba(255, 87, 34, 0.1);
+      color: #ccc;
+    }
+    
+    body.dark .footer-desc, 
+    body.dark .footer-links li a, 
+    body.dark .footer-contact-info {
+      color: #aaa;
+    }
+    
+    body.dark .footer-links li a:hover {
+      color: #ff7b54;
+    }
+    
+    body.dark .footer-bottom {
+      border-top-color: rgba(255, 255, 255, 0.05);
+      color: #777;
     }
 
     /* ===== Enhanced Animations & Transitions ===== */

--- a/faq.html
+++ b/faq.html
@@ -220,7 +220,9 @@
       <a href="cart.html" class="nav-link">Cart</a>
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
-        <button aria-label="Search" id="search-btn"></button>
+        <button aria-label="Search" id="search-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="search-svg"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        </button>
         <div class="search-suggestions" id="search-suggestions" style="display:none;"></div>
       </div>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">

--- a/faq.html
+++ b/faq.html
@@ -406,13 +406,66 @@
 
 <!-- ═══════════ FOOTER (exact match) ═══════════ -->
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>&copy; 2026 ChaatBazaar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <script src="js/cart-manager.js"></script>

--- a/favorites.html
+++ b/favorites.html
@@ -35,7 +35,9 @@
         <div class="search-bar" role="search">
           <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input"
             autocomplete="off" />
-          <button aria-label="Search" id="search-btn"></button>
+          <button aria-label="Search" id="search-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="search-svg"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+          </button>
           <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
         </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">

--- a/favorites.html
+++ b/favorites.html
@@ -68,7 +68,66 @@
     </div>
   </section>
   <footer>
-    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+    <div class="footer-container">
+      <div class="footer-column brand-col">
+        <div class="footer-brand">ChaatBazar 🍴</div>
+        <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+      </div>
+      
+      <div class="footer-column">
+        <h3>ChaatBazar</h3>
+        <ul class="footer-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="menu.html">Menu</a></li>
+          <li><a href="about.html">About Us</a></li>
+          <li><a href="orders.html">Orders</a></li>
+          <li><a href="favorites.html">Favorites</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </div>
+      
+      <div class="footer-column">
+        <h3>For Partners</h3>
+        <ul class="footer-links">
+          <li><a href="#">Partners With Us</a></li>
+          <li><a href="#">Apps For You</a></li>
+          <li><a href="#">Franchise Consulting</a></li>
+          <li><a href="#">Advertise With Us</a></li>
+          <li><a href="#">Sell On ChaatBazar</a></li>
+        </ul>
+      </div>
+      
+      <div class="footer-column">
+        <h3>Learn More</h3>
+        <ul class="footer-links">
+          <li><a href="#">Privacy & Security</a></li>
+          <li><a href="#">Terms & Conditions</a></li>
+          <li><a href="#">Help & Support</a></li>
+          <li><a href="#">Report a Fraud</a></li>
+        </ul>
+      </div>
+      
+      <div class="footer-column">
+        <div class="footer-social-wrapper">
+          <h3>Connect Us</h3>
+          <div class="footer-social-icons">
+            <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+            <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+            <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+          </div>
+        </div>
+        <h3>Contact Us</h3>
+        <ul class="footer-contact-info">
+          <li><strong>Email:</strong> support@chaatbazar.com</li>
+          <li><strong>Phone:</strong> +91 98765 43210</li>
+          <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+    </div>
   </footer>
   <script src="js/cart-manager.js"></script>
   <script src="js/recently-viewed.js"></script>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,9 @@
       <a href="#cart-sidebar" class="nav-link" id="cart-open-btn" aria-label="Open Cart">Cart (<span id="cart-count">0</span>)</a>
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
-        <button aria-label="Search" id="search-btn"></button>
+        <button aria-label="Search" id="search-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="search-svg"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        </button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">

--- a/index.html
+++ b/index.html
@@ -278,13 +278,66 @@
 
 <!-- Footer -->
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>© 2026 ChaatBazar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <div id="toast-notification" class="toast-notification"></div>

--- a/menu.html
+++ b/menu.html
@@ -33,7 +33,9 @@
       <a href="cart.html" class="nav-link">Cart</a>
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
-        <button aria-label="Search" id="search-btn"></button>
+        <button aria-label="Search" id="search-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="search-svg"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        </button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">

--- a/menu.html
+++ b/menu.html
@@ -141,13 +141,66 @@
 </section>
 
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <div id="toast-notification" class="toast-notification"></div>

--- a/orders.html
+++ b/orders.html
@@ -34,7 +34,9 @@
       <a href="cart.html" class="nav-link">Cart</a>
       <div class="search-bar" role="search">
         <input type="search" placeholder="Search menu..." aria-label="Search menu" id="search-input" autocomplete="off" />
-        <button aria-label="Search" id="search-btn"></button>
+        <button aria-label="Search" id="search-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="search-svg"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        </button>
         <div class="search-suggestions" id="search-suggestions" style="display: none;"></div>
       </div>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle Theme">

--- a/orders.html
+++ b/orders.html
@@ -200,13 +200,66 @@
 </main>
 
 <footer>
-  <div class="social-icons">
-    <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-    <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-    <a href="https://github.com" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fa-brands fa-github"></i></a>
+  <div class="footer-container">
+    <div class="footer-column brand-col">
+      <div class="footer-brand">ChaatBazar 🍴</div>
+      <p class="footer-desc">Your ultimate destination for authentic and mouth-watering Indian street food - from crispy golgappas to hot samosas. Hassle-free delivery right to your doorstep.</p>
+    </div>
+    
+    <div class="footer-column">
+      <h3>ChaatBazar</h3>
+      <ul class="footer-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="menu.html">Menu</a></li>
+        <li><a href="about.html">About Us</a></li>
+        <li><a href="orders.html">Orders</a></li>
+        <li><a href="favorites.html">Favorites</a></li>
+        <li><a href="faq.html">FAQ</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>For Partners</h3>
+      <ul class="footer-links">
+        <li><a href="#">Partners With Us</a></li>
+        <li><a href="#">Apps For You</a></li>
+        <li><a href="#">Franchise Consulting</a></li>
+        <li><a href="#">Advertise With Us</a></li>
+        <li><a href="#">Sell On ChaatBazar</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <h3>Learn More</h3>
+      <ul class="footer-links">
+        <li><a href="#">Privacy & Security</a></li>
+        <li><a href="#">Terms & Conditions</a></li>
+        <li><a href="#">Help & Support</a></li>
+        <li><a href="#">Report a Fraud</a></li>
+      </ul>
+    </div>
+    
+    <div class="footer-column">
+      <div class="footer-social-wrapper">
+        <h3>Connect Us</h3>
+        <div class="footer-social-icons">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+          <a href="https://youtube.com" target="_blank" rel="noopener noreferrer" aria-label="YouTube"><i class="fa-brands fa-youtube"></i></a>
+          <a href="https://whatsapp.com" target="_blank" rel="noopener noreferrer" aria-label="WhatsApp"><i class="fa-brands fa-whatsapp"></i></a>
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
+      </div>
+      <h3>Contact Us</h3>
+      <ul class="footer-contact-info">
+        <li><strong>Email:</strong> support@chaatbazar.com</li>
+        <li><strong>Phone:</strong> +91 98765 43210</li>
+        <li><strong>Headquarter:</strong> Bhavnagar, Gujarat, 364001</li>
+      </ul>
+    </div>
   </div>
-  <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  <div class="footer-bottom">
+    <p>&copy; 2026 ChaatBazar. All rights reserved.</p>
+  </div>
 </footer>
 
 <script src="js/accessibility.js"></script>


### PR DESCRIPTION
issuenum: #292 

Description
This PR resolves a visual issue on orders.html and cart.html where the "Skip to main content" accessibility link was persistently visible as unstyled black text on a white background above the header.

Root Cause
In css/style.css (line 2234), the closing curly brace (}) for the style rule ::-webkit-scrollbar-thumb:hover was missing. Because of this syntax error, the browser's CSS parser failed to process the subsequent .skip-link styles correctly, leaving the accessibility skip link unstyled and visible by default at the top of the viewport.

Proposed Changes
Stylesheet Fix (css/style.css)
Added the missing closing curly brace } to seal the ::-webkit-scrollbar-thumb:hover styling rule.
This successfully enables the browser to parse and apply the .skip-link absolute positioning rule (top: -40px;), hiding it off-screen on initial page load as intended.

/gssoc26