### PR TITLE
fix(i18n): preserve cart close button

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -126,7 +126,19 @@ function applyTranslations() {
   const cartHeader = document.getElementById('cart-header');
   if (cartHeader) {
     const closeBtn = document.getElementById('cart-close');
-    cartHeader.innerHTML = `${t('cart_title')} ${closeBtn ? closeBtn.outerHTML : ''}`;
+    if (closeBtn) {
+      const titleNode = Array.from(cartHeader.childNodes).find(
+        node => node.nodeType === Node.TEXT_NODE && node.textContent.trim()
+      );
+
+      if (titleNode) {
+        titleNode.textContent = `${t('cart_title')} `;
+      } else {
+        cartHeader.insertBefore(document.createTextNode(`${t('cart_title')} `), closeBtn);
+      }
+    } else {
+      cartHeader.textContent = t('cart_title');
+    }
   }
 
   const checkoutBtn = document.getElementById('checkout-btn');

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -125,19 +125,21 @@ function applyTranslations() {
 
   const cartHeader = document.getElementById('cart-header');
   if (cartHeader) {
-    const closeBtn = document.getElementById('cart-close');
+    const cartTitle = t('cart_title');
+    const closeBtn = cartHeader.querySelector('#cart-close');
+
     if (closeBtn) {
       const titleNode = Array.from(cartHeader.childNodes).find(
         node => node.nodeType === Node.TEXT_NODE && node.textContent.trim()
       );
 
       if (titleNode) {
-        titleNode.textContent = `${t('cart_title')} `;
+        titleNode.textContent = `${cartTitle} `;
       } else {
-        cartHeader.insertBefore(document.createTextNode(`${t('cart_title')} `), closeBtn);
+        cartHeader.insertBefore(document.createTextNode(`${cartTitle} `), closeBtn);
       }
     } else {
-      cartHeader.textContent = t('cart_title');
+      cartHeader.textContent = cartTitle;
     }
   }
 


### PR DESCRIPTION
## What
Closes #366. Fixes the language toggle regression where translating the cart header replaces the existing `#cart-close` button node and drops its click listener.

## How
Updated `applyTranslations()` to preserve the existing close button element and only update the cart header text node. The close button lookup is scoped to `#cart-header`, and the translated cart title is computed once before updating or inserting the text node.

## Testing
- `node --check js/i18n.js`
- `git diff --check`
- Synthetic DOM regression check with Node `vm` confirming `applyTranslations()` and `switchLanguage()` preserve the original `#cart-close` node while changing the cart title text.
- Served locally with `python3 -m http.server 8000`; verified `index.html` and `js/i18n.js` return HTTP 200 and that `index.html` loads `translations.js`, `i18n.js`, and `main.js` in order.

## Risks / Notes
No dependency changes. The broad repo syntax check `find js data -name '*.js' -print0 | xargs -0 -n1 node --check` still fails on the existing `js/main.js` duplicate `subtotal` declaration from #353:

```text
js/main.js:832
  const subtotal = getCartSubtotal();
        ^
SyntaxError: Identifier 'subtotal' has already been declared
```

That pre-existing checkout issue is handled separately in PR #364, so this PR stays focused on #366.

GitHub Actions note: latest `CI Checks` is currently `action_required` before any job starts, and the run has zero jobs listed: https://github.com/PatelHarsh2006/ChaatBazaar/actions/runs/26634013136. This is a pre-execution workflow approval state for the fork PR, not a code test failure.
