### PR TITLE
fix: add dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automatically create PRs when GitHub Actions versions become outdated, keeping the CI pipeline secure and current.

## Changes
- Created \.github/dependabot.yml\ with weekly schedule for github-actions ecosystem

Closes #393