### PR TITLE
fix: prevent TypeError on manual address invoices (closes #406)

### DIFF
--- a/js/invoice.js
+++ b/js/invoice.js
@@ -115,8 +115,12 @@ window.invoiceGenerator = (() => {
       const addrLines = [];
       if (address) {
         addrLines.push(`Source: ${address.source === 'geolocation' ? 'GPS Coordinates' : 'Manual Entry'}`);
-        addrLines.push(`Latitude: ${address.latitude.toFixed(5)}`);
-        addrLines.push(`Longitude: ${address.longitude.toFixed(5)}`);
+        if (typeof address.latitude === 'number' && typeof address.longitude === 'number') {
+          addrLines.push(`Latitude: ${address.latitude.toFixed(5)}`);
+          addrLines.push(`Longitude: ${address.longitude.toFixed(5)}`);
+        } else if (address.text) {
+          addrLines.push(`Address: ${address.text}`);
+        }
         if (order.deliveryDistance) {
           addrLines.push(`Distance: ${order.deliveryDistance.toFixed(2)} km`);
         }
@@ -285,7 +289,7 @@ window.invoiceGenerator = (() => {
           </div>
           <div style="margin-top: 10px;">
             <strong>From:</strong> ChaatBazar Central Kitchen, India Gate, New Delhi<br/>
-            <strong>Delivery:</strong> ${order.deliveryAddress ? `GPS Coordinates (${order.deliveryAddress.latitude.toFixed(4)}, ${order.deliveryAddress.longitude.toFixed(4)})` : 'Self-Counter Pickup'}
+            <strong>Delivery:</strong> ${order.deliveryAddress ? (typeof order.deliveryAddress.latitude === 'number' && typeof order.deliveryAddress.longitude === 'number' ? `GPS Coordinates (${order.deliveryAddress.latitude.toFixed(4)}, ${order.deliveryAddress.longitude.toFixed(4)})` : (order.deliveryAddress.text || 'Manual Address')) : 'Self-Counter Pickup'}
           </div>
         </div>
 


### PR DESCRIPTION
## What
Prevents unhandled TypeError crash when generating invoice PDF or print receipt for orders with manually entered addresses.

## Root cause
Lines 118-119 and 288 in invoice.js call \.toFixed()\ on \ddress.latitude\/\ddress.longitude\, which are \undefined\ when a customer uses manual address entry instead of geolocation.

## Changes
- \js/invoice.js\ — Added \	ypeof\ guards before \.toFixed()\ calls; falls back to displaying \ddress.text\ when coordinates aren't available

## Verification
- Manual address orders now show the street address instead of crashing
- Geolocation orders continue to show GPS coordinates as before
- Self-pickup orders unchanged

Closes #406