### PR TITLE
perf: debounce search suggestions input listener

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -89,6 +89,18 @@ let activeCoupon = null;
 function formatPrice(price) {
   return `₹${price}`;
 }
+
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
  
 function getCartSubtotal() {
   return cart.reduce((sum, ci) => sum + ci.item.price * ci.quantity, 0);
@@ -1230,7 +1242,7 @@ function setupSearchSuggestions() {
     suggestionsContainer.style.display = "block";
   }
  
-  searchInput.addEventListener("input", showSuggestions);
+  searchInput.addEventListener("input", debounce(showSuggestions, 300));
   searchInput.addEventListener("focus", showSuggestions);
   document.addEventListener("click", (e) => {
     if (!searchInput.contains(e.target) && !suggestionsContainer.contains(e.target)) {


### PR DESCRIPTION
Closes #476 

# Summary
Applies a 300ms input debounce threshold to reduce search suggestion recalculation frequencies.

# Changes Made
- Created a utility `debounce` helper.
- Applied the debounce wrapper to search suggestions input events.

# Testing
Verified suggestion calculations trigger only after typing pauses.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
