### PR TITLE
Add combo preview section with responsive styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3302,13 +3302,46 @@ body.dark .breakdown-row.final {
 }
 
 .combo-add-btn:hover {
-  background: #e64a19;
+  background: #e64a19; 
   transform: scale(1.05);
 }
 .combo-item-right {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+/* ===== Combo Preview ===== */
+.combo-preview {
+  padding: 3rem 1rem;
+  background: linear-gradient(180deg, #fffaf6 0%, #fff3e0 100%);
+}
+.combo-preview .container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+.combo-preview-text {
+  max-width: 760px;
+  margin: 0 auto;
+  color: #6b4a3a;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+.combo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 2.2rem;
+  border-radius: 40px;
+  font-weight: 700;
+}
+
+@media (max-width: 600px) {
+  .combo-preview { padding: 2rem 0.8rem; }
+  .combo-btn { width: 100%; max-width: 320px; }
 }
 
 


### PR DESCRIPTION
Fixed layout structure for the Smart Food Pairings component.

Adjusted margins/padding to prevent the text from overlapping with the section title and action button.

Ensured the "Explore Smart Combos" button aligns correctly within the document flow.
fixes : #564 

<img width="958" height="488" alt="Screenshot 2026-06-28 173821" src="https://github.com/user-attachments/assets/decb32e2-3536-4e30-ad7a-44130622f383" />
