### PR TITLE
strengthened the validation in login and signup pages

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -153,6 +153,22 @@
     box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.2);
 }
 
+.input-group input.invalid {
+    border-color: #dc2626;
+}
+
+.input-group input.invalid:focus {
+    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2);
+}
+
+.input-group input.valid {
+    border-color: #16a34a;
+}
+
+.input-group input.valid:focus {
+    box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.2);
+}
+
 .error-message {
     color: #dc2626;
     font-size: 0.75rem;
@@ -462,6 +478,14 @@ body.dark .input-group input::placeholder {
 
 body.dark .input-group input:focus {
   border-color: #ff6b35;
+}
+
+body.dark .input-group input.invalid {
+  border-color: #f87171;
+}
+
+body.dark .input-group input.valid {
+  border-color: #4ade80;
 }
 
 body.dark .auth-link {

--- a/js/auth.js
+++ b/js/auth.js
@@ -86,6 +86,37 @@
     setFormMessage(formId, "", "");
   }
 
+  function setFieldValidity(inputId, message, hasValue) {
+    const inputEl = document.getElementById(inputId);
+    if (!inputEl) return;
+
+    inputEl.classList.toggle("invalid", Boolean(message) && hasValue);
+    inputEl.classList.toggle("valid", !message && hasValue);
+  }
+
+  // Validates on blur immediately, then re-validates on every keystroke
+  // once a field has already been marked invalid, so errors clear as
+  // soon as the user fixes them instead of waiting for the next submit.
+  function attachLiveValidation(inputId, validatorFn) {
+    const inputEl = document.getElementById(inputId);
+    if (!inputEl) return;
+
+    const runValidation = function () {
+      const value = inputEl.value;
+      const message = validatorFn(value);
+      setFieldError(inputId, message);
+      setFieldValidity(inputId, message, value.trim().length > 0);
+      return message;
+    };
+
+    inputEl.addEventListener("blur", runValidation);
+    inputEl.addEventListener("input", function () {
+      if (inputEl.classList.contains("invalid")) {
+        runValidation();
+      }
+    });
+  }
+
   function getThemePreference() {
     return localStorage.getItem(THEME_KEY) === "dark" ? "dark" : "light";
   }
@@ -232,6 +263,15 @@
     const loginForm = document.getElementById("login-form");
     if (!loginForm) return;
 
+    attachLiveValidation("login-email", function (value) {
+      return validateEmail(value) ? "" : "Please enter a valid email address.";
+    });
+    attachLiveValidation("login-password", function (value) {
+      return String(value || "").trim().length >= 6
+        ? ""
+        : "Password must be at least 6 characters.";
+    });
+
     loginForm.addEventListener("submit", function (event) {
       event.preventDefault();
 
@@ -246,12 +286,18 @@
 
       if (!validateEmail(email)) {
         setFieldError("login-email", "Please enter a valid email address.");
+        setFieldValidity("login-email", "invalid", Boolean(email));
         hasError = true;
+      } else {
+        setFieldValidity("login-email", "", true);
       }
 
       if (password.length < 6) {
         setFieldError("login-password", "Password must be at least 6 characters.");
+        setFieldValidity("login-password", "invalid", Boolean(password));
         hasError = true;
+      } else {
+        setFieldValidity("login-password", "", true);
       }
 
       if (hasError) {
@@ -286,6 +332,28 @@
     const signupForm = document.getElementById("signup-form");
     if (!signupForm) return;
 
+    attachLiveValidation("signup-name", function (value) {
+      return String(value || "").trim() ? "" : "Name is required.";
+    });
+    attachLiveValidation("signup-email", function (value) {
+      const email = normalizeEmail(value);
+      if (!validateEmail(email)) return "Please enter a valid email address.";
+      const users = getUsers();
+      const emailAlreadyExists = users.some((user) => normalizeEmail(user.email) === email);
+      return emailAlreadyExists ? "This email is already registered. Please log in." : "";
+    });
+    attachLiveValidation("signup-password", function (value) {
+      return String(value || "").trim().length >= 6
+        ? ""
+        : "Password must be at least 6 characters.";
+    });
+    attachLiveValidation("signup-phone", function (value) {
+      return validatePhone(value) ? "" : "Phone number must contain exactly 10 digits.";
+    });
+    attachLiveValidation("signup-location", function (value) {
+      return String(value || "").trim() ? "" : "Location is required.";
+    });
+
     signupForm.addEventListener("submit", function (event) {
       event.preventDefault();
 
@@ -310,33 +378,49 @@
 
       if (!name) {
         setFieldError("signup-name", "Name is required.");
+        setFieldValidity("signup-name", "invalid", Boolean(name));
         hasError = true;
+      } else {
+        setFieldValidity("signup-name", "", true);
       }
 
       if (!validateEmail(email)) {
         setFieldError("signup-email", "Please enter a valid email address.");
+        setFieldValidity("signup-email", "invalid", Boolean(email));
         hasError = true;
+      } else {
+        setFieldValidity("signup-email", "", true);
       }
 
       if (password.length < 6) {
         setFieldError("signup-password", "Password must be at least 6 characters.");
+        setFieldValidity("signup-password", "invalid", Boolean(password));
         hasError = true;
+      } else {
+        setFieldValidity("signup-password", "", true);
       }
 
       if (!validatePhone(phone)) {
         setFieldError("signup-phone", "Phone number must contain exactly 10 digits.");
+        setFieldValidity("signup-phone", "invalid", Boolean(phone));
         hasError = true;
+      } else {
+        setFieldValidity("signup-phone", "", true);
       }
 
       if (!location) {
         setFieldError("signup-location", "Location is required.");
+        setFieldValidity("signup-location", "invalid", Boolean(location));
         hasError = true;
+      } else {
+        setFieldValidity("signup-location", "", true);
       }
 
       const users = getUsers();
       const emailAlreadyExists = users.some((user) => normalizeEmail(user.email) === email);
       if (emailAlreadyExists) {
         setFieldError("signup-email", "This email is already registered. Please log in.");
+        setFieldValidity("signup-email", "invalid", true);
         hasError = true;
       }
 


### PR DESCRIPTION
## Title
Strengthen validation and UX feedback for login and signup forms (#580)

## Summary
Closes #580.

Login and signup forms previously only validated on submit — a user could fill in every field wrong and get no feedback until they clicked the button, and the "email already registered" check only ran at the very end. This PR adds real-time, field-level validation with clear visual states:

- Each field now validates on blur (first check) and re-validates on every keystroke once it's been marked invalid, so errors clear the moment the user fixes them instead of waiting for the next submit.
- Inputs get a red border (`.invalid`) or green border (`.valid`) reflecting their current state, in both light and dark theme.
- Signup's "this email is already registered" check now runs on blur of the email field, not only after clicking Sign Up.
- Existing field-specific error messages (e.g. "Password must be at least 6 characters.", "Phone number must contain exactly 10 digits.") are unchanged — they now just surface earlier and are backed by the new valid/invalid styling.
- Submit-time validation still runs as the final gate and now also applies the same valid/invalid classes, so the two paths stay visually consistent.

`profile.html` was reviewed but not changed — it only displays saved account details and has no editable form, so it wasn't in scope.

## Changes
- `js/auth.js`: added `setFieldValidity` and `attachLiveValidation` helpers; wired live validation into `handleLoginPage` and `handleSignupPage`; submit handlers now also set valid/invalid classes alongside existing error messages.
- `css/auth.css`: added `.input-group input.invalid` / `.input-group input.valid` styles (border + focus ring) for both light and dark mode.

Before:
<img width="1470" height="835" alt="Screenshot 2026-07-27 at 7 36 15 PM" src="https://github.com/user-attachments/assets/deb8cb4c-66d2-47f9-b169-dec861e37293" />

After:
<img width="1470" height="837" alt="Screenshot 2026-07-27 at 7 35 40 PM" src="https://github.com/user-attachments/assets/31b36df6-570d-40be-8c9e-da7c9a8fa78e" />


## Test Plan
- [ ] Open `login.html`: leave email/password empty, tab through fields — inline error + red border appears per field without submitting.
- [ ] Fix each field — border turns green and error clears immediately (no submit needed).
- [ ] Submit with invalid data — same red/green states apply, plus the existing "Please fix the highlighted fields." message.
- [ ] Open `signup.html`: repeat the same check for name, email, password, phone, location.
- [ ] On `signup.html`, enter an email that's already registered and blur the field — "This email is already registered. Please log in." appears immediately, before submitting.
- [ ] Toggle dark mode on both pages and confirm the red/green borders remain readable against the dark input background.
- [ ] Confirm existing login/signup happy-path flows (valid data → redirect to `index.html`) still work unchanged.
