### PR TITLE
docs: fix typo Wesbite -> Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Built with modern, lightweight web technologies:
 
 ## Important points for Contributors to keep in Mind :
 
-1. Maintain the Orange theme, throughout the Wesbite.
+1. Maintain the Orange theme, throughout the Website.
 
 2. Include "Before" and "After" screenshots of the webpage for all changes, in the Pull Request description.
 


### PR DESCRIPTION
PR Description: Fixed spelling typo "Wesbite" → "Website" in the Contributors section of README.md.

Issue: closes #None (just a documentation quick fix )